### PR TITLE
Treat ReactJS component modules as Javascript files

### DIFF
--- a/src/main/kotlin/app/extractors/JavascriptExtractor.kt
+++ b/src/main/kotlin/app/extractors/JavascriptExtractor.kt
@@ -10,7 +10,7 @@ import app.model.DiffFile
 class JavascriptExtractor : ExtractorInterface {
     companion object {
         val LANGUAGE_NAME = "javascript"
-        val FILE_EXTS = listOf("js")
+        val FILE_EXTS = listOf("js", "jsx")
         val LIBRARIES = ExtractorInterface.getLibraries("js")
         val evaluator by lazy {
             ExtractorInterface.getLibraryClassifier(LANGUAGE_NAME)


### PR DESCRIPTION
Allow Sourcerer to process `*.jsx` files containing [ReactJS](https://reactjs.org/docs/introducing-jsx.html) components as Javascript modules.

_UPD:_ given the popularity of ReactJS and JSX (even outside of React ecosystem) there's large codebases made up with JSX modules.