### PR TITLE
fix: remove ruby-is-rails assumption (#239)

### DIFF
--- a/src/main/kotlin/app/extractors/RubyExtractor.kt
+++ b/src/main/kotlin/app/extractors/RubyExtractor.kt
@@ -34,9 +34,6 @@ class RubyExtractor : ExtractorInterface {
             }
         }
 
-        // TODO(lyaronskaya): read external files
-        imports.add("rails")
-
         return imports.toList()
     }
 

--- a/src/test/kotlin/test/tests/extractors/ExtractorTest.kt
+++ b/src/test/kotlin/test/tests/extractors/ExtractorTest.kt
@@ -116,12 +116,6 @@ class ExtractorTest : Spek({
             assertExtractsLineLibraries("com.github.kittinunf.fuel",
                     line, KotlinExtractor())
         }
-
-        it("ruby extractor extracts rails") {
-            val line = "class Article < ActiveRecord::Base"
-            assertExtractsLineLibraries("rails",
-                    line, RubyExtractor())
-        }
     }
 
     given("code line doesn't use libraries" ) {


### PR DESCRIPTION
The line being removed currently causes (sometimes wildly) incorrect tagging of projects.
Future work on identifying rails projects should be more careful.